### PR TITLE
「早見表」「試算方法」に注釈・テキストを追加

### DIFF
--- a/src/app/home/method/method.component.html
+++ b/src/app/home/method/method.component.html
@@ -32,7 +32,7 @@
           <td>50<span class="unit">%</span></td>
         </tr>
         <tr>
-          <th>介護保険</th>
+          <th>介護保険<sup>※1</sup></th>
           <td>
             <small>標準報酬月額の</small>
             {{ rate.socialIns.nursingInsRate }}<span class="unit">%</span>
@@ -50,7 +50,7 @@
           <td>100<span class="unit">%</span></td>
         </tr>
         <tr>
-          <th>労災保険</th>
+          <th>労災保険<sup>※2</sup></th>
           <td>
             <small>総支給額の</small>
             {{ rate.compensationIns.rate }}/1000
@@ -59,7 +59,7 @@
           <td>100<span class="unit">%</span></td>
         </tr>
         <tr>
-          <th>雇用保険</th>
+          <th>雇用保険<sup>※3</sup></th>
           <td>
             <small>総支給額の</small>
             {{ rate.unemploymentIns.rate }}/1000
@@ -69,6 +69,14 @@
         </tr>
       </tbody>
     </table>
+    <div class="method__annotation">
+      <p>
+        ※1
+        介護保険の被保険者（介護保険料支払対象者）は、40歳から64歳までの方です。
+      </p>
+      <p>※2 「その他の各種事業」の保険料率です。</p>
+      <p>※3 「一般の事業」の保険料率です。</p>
+    </div>
     <h2 class="main-title">各種控除の試算方法</h2>
     <dl class="method__data">
       <dt>社会保険料</dt>
@@ -80,20 +88,6 @@
         <span>
           「<a [href]="rate.socialIns.url" target="_blank">{{
             rate.socialIns.title
-          }}</a
-          >」
-        </span>
-      </dd>
-      <dt>雇用保険料</dt>
-      <dd>
-        事業の種類により、雇用保険料率は異なります。<br />
-        こちらの試算ツールでは、「一般の事業」の保険料率を基に算出します。
-        <span>
-          雇用保険料の算出に関する詳細は、厚生労働省HPの下記のページをご参照ください。
-        </span>
-        <span>
-          「<a [href]="rate.unemploymentIns.url" target="_blank">{{
-            rate.unemploymentIns.title
           }}</a
           >」
         </span>
@@ -112,9 +106,24 @@
           >」
         </span>
       </dd>
+      <dt>雇用保険料</dt>
+      <dd>
+        事業の種類により、雇用保険料率は異なります。<br />
+        こちらの試算ツールでは、「一般の事業」の保険料率を基に算出します。
+        <span>
+          雇用保険料の算出に関する詳細は、厚生労働省HPの下記のページをご参照ください。
+        </span>
+        <span>
+          「<a [href]="rate.unemploymentIns.url" target="_blank">{{
+            rate.unemploymentIns.title
+          }}</a
+          >」
+        </span>
+      </dd>
       <dt>源泉所得税</dt>
       <dd>
-        源泉所得税の計算は、源泉徴収税額表の電子計算機等を使用して源泉徴収税額を計算する方法に基づいて算出しています。
+        源泉所得税の計算は、電算機計算の特例に基づいて算出しています。<br />
+        税額表により求めた税額との差額が生じることがありますが、実際の税額は年末調整で精算されます。
         <span>
           源泉所得税額の算出に関する詳細は、国税庁HPの下記のページをご参照ください。
         </span>

--- a/src/app/home/method/method.component.scss
+++ b/src/app/home/method/method.component.scss
@@ -13,13 +13,11 @@
     width: 100%;
     margin-top: 32px;
     font-size: 12px;
-    margin-bottom: 40px;
     border-collapse: collapse;
     border-spacing: 0;
     @include sm {
       font-size: 14px;
       margin-top: 40px;
-      margin-bottom: 80px;
     }
     th,
     td {
@@ -79,6 +77,26 @@
     tbody {
       th {
         text-align: left;
+      }
+    }
+  }
+  &__annotation {
+    margin-top: 12px;
+    margin-bottom: 40px;
+    color: $color-font-700;
+    font-size: 10px;
+    @include sm {
+      margin-top: 12px;
+      margin-bottom: 80px;
+      font-size: 12px;
+    }
+    p {
+      margin-top: 0;
+      margin-bottom: 0;
+      padding-left: 2em;
+      text-indent: -2em;
+      &:not(:first-of-type) {
+        margin-top: 4px;
       }
     }
   }


### PR DESCRIPTION
fix #47 